### PR TITLE
first pass at ragas eval

### DIFF
--- a/ragas_benchmark/ragas_test_traces.py
+++ b/ragas_benchmark/ragas_test_traces.py
@@ -1,0 +1,98 @@
+import src.config as runtime_config
+from langfuse import Langfuse
+langfuse = Langfuse(
+  secret_key=runtime_config.LANGFUSE_SECRET_KEY,
+  public_key=runtime_config.LANGFUSE_PUBLIC_KEY,
+  host=runtime_config.LANGFUSE_HOST
+)
+
+
+def get_observations_filtered(observation_filters: dict= None):
+    observations = langfuse.fetch_observations(**observation_filters)
+    return observations
+
+
+def get_traces_filtered( observation_name: str,  trace_filters: dict= None):
+    # assuming that traces are tagged with code-names for the LLM app...
+    # let's first fetch all traces with that application name
+    all_traces = langfuse.fetch_traces(**trace_filters)
+    # now for each trace ... we will find all the generation observations... this will include
+    # data about the input (prompt + context) and the llm answer... reformat them as user_input:... , response: ...
+
+    # flat_responses is our evaluation input... (https://docs.ragas.io/en/stable/getstarted/evals/#evaluating-on-a-dataset)
+    flat_responses = []
+    for trace in all_traces.data:
+        observations = get_observations_filtered({'trace_id': trace.id, 'type': 'GENERATION'})
+        if not observations.data:
+            continue
+
+        for observation in observations.data:
+            if observation.metadata.get('name') == observation_name:
+                # append each observation input / output to our dataset...
+                flat_responses.append(
+                    {
+                        # this line might be a little flaky ... is it always true that [0]th element is the one that has
+                        # the context and used for generation ...?
+                        'user_input': trace.input['input'], #observation.input[0]['content'],
+                        'retrieved_contexts': [observation.input[0]['content']],
+                        'reference': observation.input[0]['content'],
+                        'response': observation.output['content'],
+                    }
+                )
+    # this will be the input for evaluation...
+    return flat_responses
+
+
+# fetch traces:
+    # filter the traces by application environment and possibly date range
+    # once traces are fetched look for generation observations under each trace...
+    # these would give input and output to measure... but how do we know if these observations
+    # are part of the answering or not ...
+    # one way is changing the koios generation code to add names that are specific to generation steps...
+    # other way is to look for parent observations and find generation type observations under those...
+
+
+if __name__ == '__main__':
+    import json
+    #TODO parametrize app name, date time range and observation name to filter the datasets for evaluation...
+    app_id = "QV_KG_NO_ROUTE"
+    observations_name = "answer_generation"
+    # these are not used yet ... but need to ...
+    filters = {
+        'tags': [app_id]
+    }
+
+    # watch out for pagenation might need to do something other than the default there...
+    obvs = get_traces_filtered(
+        observation_name=observations_name,
+        trace_filters=filters
+    )
+
+    from ragas import EvaluationDataset
+    # construct the rages dataset
+    evaluation_dataset = EvaluationDataset.from_list(obvs)
+
+    # do evaluation ...
+    from ragas import evaluate
+    from ragas.llms import LangchainLLMWrapper
+    from langchain_openai import ChatOpenAI
+
+    llm = ChatOpenAI(
+        api_key= "EMPTY",
+        base_url=runtime_config.LLM_URL,
+        model=runtime_config.GEN_MODEL_NAME
+    )
+    evaluator_llm = LangchainLLMWrapper(langchain_llm=llm)
+    # evaluation metrics ....
+    from ragas.metrics import LLMContextRecall, Faithfulness, FactualCorrectness, AnswerCorrectness
+
+
+    result = evaluate(dataset=evaluation_dataset, metrics=[
+        AnswerCorrectness()
+        # Faithfulness(),
+        # LLMContextRecall(),
+        # FactualCorrectness()
+    ],
+                      llm=evaluator_llm)
+
+    print(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ langgraph
 falkordb
 pandas
 nemoguardrails
+ragas

--- a/src/chains/kg_chain.py
+++ b/src/chains/kg_chain.py
@@ -56,7 +56,7 @@ class KGChain:
     #  Begin Chain definitions
     ####
     def as_concept_extraction_chain(self):
-        return (self.CONCEPT_EXTRACTION_PROMPT | self.llm | StrOutputParser()).with_config(
+        return (self.CONCEPT_EXTRACTION_PROMPT | self.llm.with_config(name='concept_extraction') | StrOutputParser()).with_config(
             run_name="concept_extraction")
 
     def as_retrival_chain(self):

--- a/src/chains/question_lookup_chain.py
+++ b/src/chains/question_lookup_chain.py
@@ -66,7 +66,7 @@ class QuestionLookupChain:
                     run_name="format_chat_history"
                 )
                 | self.REPHRASE_PROMPT
-                | self.llm
+                | self.llm.with_config(name='rephrase_user_query')
                 | StrOutputParser()
             ),
             # no chat history , pass the whole question
@@ -92,7 +92,8 @@ class QuestionLookupChain:
             }
         ).with_types(input_type=Question).with_config(run_name="question_lookup_chain")
 
-        answer_chain = (self.ANSWER_GENERATION_PROMPT | self.llm | StrOutputParser())
+        answer_chain = ((self.ANSWER_GENERATION_PROMPT | self.llm | StrOutputParser())
+                        .with_config(name='answer_generation'))
         generative_chain = (_inputs | RunnableParallel(
             {
                 "output":  RunnableLambda(lambda x: {

--- a/src/chains/qvkg_chain.py
+++ b/src/chains/qvkg_chain.py
@@ -82,7 +82,7 @@ Always cite specific studies with their IDs when they appear in your answer.
                         "kg_context": x["kg_context"],
                         "qv_context": x["qv_context"],
                         "chat_history": x["chat_history"]
-                    }) | self.COMBINED_ANSWER_PROMPT | self.llm | StrOutputParser(),
+                    }) | self.COMBINED_ANSWER_PROMPT | self.llm.with_config(name="answer_generation") | StrOutputParser(),
                     "extra": RunnableLambda(lambda x: {"kg_extra": x["kg_extra"]})
                 })
             ),

--- a/src/config.py
+++ b/src/config.py
@@ -25,6 +25,7 @@ REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", "")
 REDIS_GRAPH_NAME = os.getenv("REDIS_GRAPH_NAME", "")
 TMP_DIR = os.getenv("TMP_DIR", os.path.join(os.path.dirname(os.path.realpath(__file__)),'..', 'tmp'))
 ENVIRONMENT= os.getenv("ENVIRONMENT", "production")
+APP_ID = os.getenv("APP_ID", "QV_KG_NO_ROUTE")
 
 
 
@@ -53,6 +54,7 @@ def configure_langfuse(runnable):
             },
             tags=[
                 GEN_MODEL_NAME,
+                APP_ID
             ],
             environment=ENVIRONMENT
         )


### PR DESCRIPTION
This PR adds in Ragas benchmarking setup , 
A few notes: 
1. I have named the llm generation step in the traces to make sure things we can easily get them from the trace observations (spans), using the `self.llm.with_config(name=x)` method. 
2. I have added additional tag to the bigger trace with app_id that is added to all the traces... we need to make sure that app_id  is some thing we keep track of for an instance  and that if it is a common knowledge. 

